### PR TITLE
update C seed generation

### DIFF
--- a/src/C/imagemorph.c
+++ b/src/C/imagemorph.c
@@ -25,6 +25,7 @@ Copyright M.Bulacu and L.Schomaker 2009,2016
 # include <string.h>
 # include <math.h>
 # include <time.h>
+#include <sys/time.h>
 # include <unistd.h>
 
 typedef struct {
@@ -356,6 +357,16 @@ void rubbersheet( Pixel ** input, Pixel ** output, const int h, const int w,
 	free( d_y );
 }
 
+void random_seed_usec_time()
+{
+	struct timeval ct;
+	static int it;
+
+	gettimeofday(&ct, NULL);
+	it = ct.tv_sec * 1000000 + ct.tv_usec;
+	srand48((long int)it);
+	srand((unsigned int)it);
+}
 
 Pixel ** elastic_morphing( Pixel ** input, int h, int w, double amp, double sigma )
 {
@@ -363,7 +374,7 @@ Pixel ** elastic_morphing( Pixel ** input, int h, int w, double amp, double sigm
 	int i;
 
 // Seed the random number generator
-	srand48( (unsigned int)getpid( ) + (unsigned int) time( NULL ) );
+	random_seed_usec_time();
 
 // Allocate the output image
 	output = (Pixel **) malloc( h * sizeof(Pixel *) );


### PR DESCRIPTION
Reason for change:
The way that the seed is currently generated, the seed does not keep up with the IO speed of what is with the Python wrapper. A hack around this was to use time.sleep(t) with t larger than 1. While functional, this approach is very slow.

Justification of change:
During todays lecture I mentioned the duplication issues that our team had using the C image morphing tool.
In response professor Lambert sent the following code snippet in the Black Board Collaborate chat.

```
void random_seed_usec_time()
{
            struct timeval ct;
            static int it;
            double r;

            gettimeofday(&ct, NULL);
            it = ct.tv_sec * 1000000 + ct.tv_usec;
            srand48((long int) it);
            srand((unsigned int) it);
            r = drand48();
}
```

He also included the following article <medium.com/@ODSC/properly-setting-the-random-seed-in-ml-experiments-not-as-simple-as-you-might-imagine-219969c84752>.

Initiall I ignored his proposal and simply removed the line where the seed was set. This lead to the desired behavior of no duplicates and fast execution. However the drand48 documentation at <https://pubs.opengroup.org/onlinepubs/7908799/xsh/drand48.html> indicates that a seed should always be set.
So Professor Lambert's code is preferable.

